### PR TITLE
Jackson 2.7.3 Upgrade

### DIFF
--- a/maven/maven-wrapper.properties
+++ b/maven/maven-wrapper.properties
@@ -1,3 +1,3 @@
 #Maven download properties
-#Wed Dec 09 17:47:34 UTC 2015
-distributionUrl=http\://maven.ibiblio.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip
+#Wed Mar 23 23:44:02 UTC 2016
+distributionUrl=https\://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.arpnetworking.build</groupId>
     <artifactId>arpnetworking-parent-pom</artifactId>
-    <version>1.0.18</version>
+    <version>1.0.20</version>
     <relativePath />
   </parent>
 
@@ -86,15 +86,15 @@
     -->
 
     <!--Dependency versions-->
-    <arpnetworking.commons.version>1.1.0</arpnetworking.commons.version>
+    <arpnetworking.commons.version>1.3.0</arpnetworking.commons.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
-    <jackson.version>2.6.2</jackson.version>
+    <jackson.version>2.7.3</jackson.version>
     <json-jackson-coreutils.version>1.8</json-jackson-coreutils.version>
     <json-schema-core.version>1.2.5</json-schema-core.version>
     <json-schema-validator.version>2.2.6</json-schema-validator.version>
     <jsr305.version>3.0.0</jsr305.version>
     <junit.version>4.12</junit.version>
-    <logback.steno.version>1.11.1</logback.steno.version>
+    <logback.steno.version>1.13.0</logback.steno.version>
     <logback.version>1.1.3</logback.version>
     <mockito.version>1.10.19</mockito.version>
     <slf4j.version>1.7.12</slf4j.version>

--- a/src/main/java/com/arpnetworking/metrics/impl/TsdMetricsFactory.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/TsdMetricsFactory.java
@@ -15,7 +15,7 @@
  */
 package com.arpnetworking.metrics.impl;
 
-import com.arpnetworking.commons.hostresolver.DefaultHostResolver;
+import com.arpnetworking.commons.hostresolver.CachingHostResolver;
 import com.arpnetworking.commons.hostresolver.HostResolver;
 import com.arpnetworking.metrics.Metrics;
 import com.arpnetworking.metrics.MetricsFactory;
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -213,6 +214,15 @@ public class TsdMetricsFactory implements MetricsFactory {
             this(DEFAULT_HOST_RESOLVER, LOGGER);
         }
 
+        /**
+         * Public constructor.
+         *
+         * @param hostResolver The <code>HostResolver</code> instance to use to determine the default host name.
+         */
+        public Builder(final HostResolver hostResolver) {
+            this(hostResolver, LOGGER);
+        }
+
         // NOTE: Package private for testing
         /* package private */ Builder(final HostResolver hostResolver, final Logger logger) {
             _hostResolver = hostResolver;
@@ -323,6 +333,6 @@ public class TsdMetricsFactory implements MetricsFactory {
         private String _clusterName;
         private String _hostName;
 
-        private static final HostResolver DEFAULT_HOST_RESOLVER = new DefaultHostResolver();
+        private static final HostResolver DEFAULT_HOST_RESOLVER = new CachingHostResolver(Duration.ofMinutes(1));
     }
 }

--- a/src/test/java/com/arpnetworking/metrics/impl/StenoLogSinkTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/StenoLogSinkTest.java
@@ -19,6 +19,7 @@ import com.arpnetworking.metrics.ComplexCompoundUnit;
 import com.arpnetworking.metrics.Quantity;
 import com.arpnetworking.metrics.Sink;
 import com.arpnetworking.metrics.Units;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,7 +68,9 @@ public class StenoLogSinkTest {
                 objectMapper,
                 logger);
 
-        Mockito.doThrow(new JsonMappingException("JsonMappingException")).when(objectMapper).writeValueAsString(Mockito.any());
+        Mockito.doThrow(new JsonMappingException(Mockito.mock(JsonParser.class), "JsonMappingException"))
+                .when(objectMapper)
+                .writeValueAsString(Mockito.any());
         recordEmpty(sink);
         Mockito.verify(logger).warn(
                 Mockito.argThat(Matchers.any(String.class)),

--- a/src/test/java/com/arpnetworking/metrics/impl/TsdLogSinkTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/TsdLogSinkTest.java
@@ -19,6 +19,7 @@ import com.arpnetworking.metrics.ComplexCompoundUnit;
 import com.arpnetworking.metrics.Quantity;
 import com.arpnetworking.metrics.Sink;
 import com.arpnetworking.metrics.Units;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,7 +68,9 @@ public class TsdLogSinkTest {
                 objectMapper,
                 logger);
 
-        Mockito.doThrow(new JsonMappingException("JsonMappingException")).when(objectMapper).writeValueAsString(Mockito.any());
+        Mockito.doThrow(new JsonMappingException(Mockito.mock(JsonParser.class), "JsonMappingException"))
+                .when(objectMapper)
+                .writeValueAsString(Mockito.any());
         recordEmpty(sink);
         Mockito.verify(logger).warn(
                 Mockito.argThat(Matchers.any(String.class)),

--- a/src/test/java/com/arpnetworking/metrics/impl/TsdMetricsFactoryTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/TsdMetricsFactoryTest.java
@@ -238,6 +238,29 @@ public class TsdMetricsFactoryTest {
     }
 
     @Test
+    public void testBuilderWithHostProvider() throws UnknownHostException {
+        final HostResolver hostResolver = Mockito.mock(HostResolver.class);
+        Mockito.doReturn("foo.example.com").when(hostResolver).getLocalHostName();
+
+        final TsdMetricsFactory metricsFactory = (TsdMetricsFactory) new TsdMetricsFactory.Builder(hostResolver)
+                .setClusterName("MyCluster")
+                .setServiceName("MyService")
+                .build();
+
+        Assert.assertEquals("foo.example.com", metricsFactory.getHostName());
+        Assert.assertEquals("MyService", metricsFactory.getServiceName());
+        Assert.assertEquals("MyCluster", metricsFactory.getClusterName());
+        Assert.assertEquals(1, metricsFactory.getSinks().size());
+        Assert.assertTrue(metricsFactory.getSinks().get(0) instanceof StenoLogSink
+                || metricsFactory.getSinks().get(0) instanceof TsdLogSink);
+
+        final Metrics metrics = metricsFactory.create();
+        Assert.assertNotNull(metrics);
+        Assert.assertTrue(metrics instanceof TsdMetrics);
+        Mockito.verify(hostResolver).getLocalHostName();
+    }
+
+    @Test
     public void testToString() {
         final String asString = new TsdMetricsFactory.Builder()
                 .setClusterName("MyCluster")


### PR DESCRIPTION
Upgrade to Jackson 2.7.3 includes upgrade of Commons to 1.13.0 and usage of CachingHostResolver to improve performance with cache ttl of 1 minute