### PR TITLE
…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     -->
 
     <!--Dependency versions-->
-    <arpnetworking.commons.version>1.3.0</arpnetworking.commons.version>
+    <arpnetworking.commons.version>1.7.1</arpnetworking.commons.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <jackson.version>2.7.4</jackson.version>
     <json-jackson-coreutils.version>1.8</json-jackson-coreutils.version>

--- a/src/test/java/com/arpnetworking/metrics/impl/TsdMetricsFactoryTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/TsdMetricsFactoryTest.java
@@ -15,7 +15,7 @@
  */
 package com.arpnetworking.metrics.impl;
 
-import com.arpnetworking.commons.hostresolver.DefaultHostResolver;
+import com.arpnetworking.commons.hostresolver.BackgroundCachingHostResolver;
 import com.arpnetworking.commons.hostresolver.HostResolver;
 import com.arpnetworking.metrics.Event;
 import com.arpnetworking.metrics.Metrics;
@@ -24,12 +24,14 @@ import com.arpnetworking.metrics.Sink;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
 import java.io.File;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -51,7 +53,7 @@ public class TsdMetricsFactoryTest {
                 "MyCluster",
                 new File("./"));
 
-        Assert.assertEquals(DEFAULT_HOST_RESOLVER.getLocalHostName(), metricsFactory.getHostName());
+        Assert.assertTrue(metricsFactory.getHostResolver() instanceof BackgroundCachingHostResolver);
         Assert.assertEquals("MyService", metricsFactory.getServiceName());
         Assert.assertEquals("MyCluster", metricsFactory.getClusterName());
         Assert.assertEquals(1, metricsFactory.getSinks().size());
@@ -73,7 +75,7 @@ public class TsdMetricsFactoryTest {
                 .setServiceName("MyService")
                 .build();
 
-        Assert.assertEquals("MyHost", metricsFactory.getHostName());
+        Assert.assertSame(hostResolver, metricsFactory.getHostResolver());
         Assert.assertEquals("MyService", metricsFactory.getServiceName());
         Assert.assertEquals("MyCluster", metricsFactory.getClusterName());
         Assert.assertEquals(1, metricsFactory.getSinks().size());
@@ -97,7 +99,7 @@ public class TsdMetricsFactoryTest {
                 .setSinks(null)
                 .build();
 
-        Assert.assertEquals("MyHost", metricsFactory.getHostName());
+        Assert.assertSame(hostResolver, metricsFactory.getHostResolver());
         Assert.assertEquals("MyService", metricsFactory.getServiceName());
         Assert.assertEquals("MyCluster", metricsFactory.getClusterName());
         Assert.assertEquals(1, metricsFactory.getSinks().size());
@@ -111,38 +113,55 @@ public class TsdMetricsFactoryTest {
     }
 
     @Test
-    public void testBuilderOverrideHost() throws UnknownHostException {
+    public void testBuilderNullHostResolver() throws UnknownHostException {
         final Logger logger = Mockito.mock(Logger.class);
+        final Sink sink = Mockito.mock(Sink.class);
         final HostResolver hostResolver = Mockito.mock(HostResolver.class);
         Mockito.doReturn("MyHost").when(hostResolver).getLocalHostName();
-        final TsdMetricsFactory metricsFactory = (TsdMetricsFactory) new TsdMetricsFactory.Builder(hostResolver, logger)
-                .setHostName("Foo")
+        final TsdMetricsFactory metricsFactory = (TsdMetricsFactory) new TsdMetricsFactory.Builder(null, logger)
                 .setClusterName("MyCluster")
                 .setServiceName("MyService")
+                .setSinks(Collections.singletonList(sink))
                 .build();
 
-        Assert.assertEquals("Foo", metricsFactory.getHostName());
+        Assert.assertTrue(metricsFactory.getHostResolver() instanceof BackgroundCachingHostResolver);
+        Assert.assertEquals("MyService", metricsFactory.getServiceName());
+        Assert.assertEquals("MyCluster", metricsFactory.getClusterName());
+        Assert.assertEquals(1, metricsFactory.getSinks().size());
+        Assert.assertSame(sink, metricsFactory.getSinks().get(0));
+
+        final Metrics metrics = metricsFactory.create();
+        Assert.assertNotNull(metrics);
+        Assert.assertTrue(metrics instanceof TsdMetrics);
+        metrics.close();
+        Mockito.verify(sink).record(Mockito.any(Event.class));
     }
 
     @Test
     public void testBuilderHostResolverFailure() throws UnknownHostException {
         final Logger logger = Mockito.mock(Logger.class);
+        final Sink sink = Mockito.mock(Sink.class);
         final HostResolver hostResolver = Mockito.mock(HostResolver.class);
         Mockito.doThrow(new UnknownHostException()).when(hostResolver).getLocalHostName();
-        final TsdMetricsFactory metricsFactory = (TsdMetricsFactory) new TsdMetricsFactory.Builder(hostResolver, logger)
+
+        final TsdMetricsFactory.Builder metricsFactoryBuilder = new TsdMetricsFactory.Builder(hostResolver, logger)
                 .setClusterName("MyCluster")
                 .setServiceName("MyService")
-                .build();
+                .setSinks(Collections.singletonList(sink));
 
-        Mockito.verify(logger).warn(Mockito.anyString());
+        final TsdMetricsFactory metricsFactory = new TsdMetricsFactory(metricsFactoryBuilder, logger);
+
         Assert.assertEquals(1, metricsFactory.getSinks().size());
-        Assert.assertTrue(metricsFactory.getSinks().get(0) instanceof WarningSink);
+        Assert.assertSame(sink, metricsFactory.getSinks().get(0));
 
         @SuppressWarnings("resource")
         final Metrics metrics = metricsFactory.create();
+        Mockito.verify(logger).warn(Mockito.anyString(), Mockito.any(UnknownHostException.class));
         Assert.assertNotNull(metrics);
         Assert.assertTrue(metrics instanceof TsdMetrics);
         metrics.close();
+
+        Mockito.verify(sink, Mockito.never()).record(Mockito.any(Event.class));
     }
 
     @Test
@@ -220,44 +239,64 @@ public class TsdMetricsFactoryTest {
     }
 
     @Test
-    public void testBuilderFailureHostName() {
-        final Logger logger = Mockito.mock(Logger.class);
-        final HostResolver hostResolver = Mockito.mock(HostResolver.class);
-        final TsdMetricsFactory metricsFactory = (TsdMetricsFactory) new TsdMetricsFactory.Builder(hostResolver, logger)
-                .setServiceName("MyService")
-                .setClusterName("MyCluster")
-                .build();
-        Mockito.verify(logger).warn(Mockito.anyString());
-        Assert.assertEquals(1, metricsFactory.getSinks().size());
-        Assert.assertTrue(metricsFactory.getSinks().get(0) instanceof WarningSink);
-        @SuppressWarnings("resource")
-        final Metrics metrics = metricsFactory.create();
-        Assert.assertNotNull(metrics);
-        Assert.assertTrue(metrics instanceof TsdMetrics);
-        metrics.close();
-    }
-
-    @Test
-    public void testBuilderWithHostProvider() throws UnknownHostException {
+    public void testBuilderHostResolver() throws UnknownHostException {
         final HostResolver hostResolver = Mockito.mock(HostResolver.class);
         Mockito.doReturn("foo.example.com").when(hostResolver).getLocalHostName();
+        final Sink sink = Mockito.mock(Sink.class);
 
         final TsdMetricsFactory metricsFactory = (TsdMetricsFactory) new TsdMetricsFactory.Builder(hostResolver)
                 .setClusterName("MyCluster")
                 .setServiceName("MyService")
+                .setSinks(Collections.singletonList(sink))
                 .build();
 
-        Assert.assertEquals("foo.example.com", metricsFactory.getHostName());
+        Assert.assertSame(hostResolver, metricsFactory.getHostResolver());
         Assert.assertEquals("MyService", metricsFactory.getServiceName());
         Assert.assertEquals("MyCluster", metricsFactory.getClusterName());
         Assert.assertEquals(1, metricsFactory.getSinks().size());
-        Assert.assertTrue(metricsFactory.getSinks().get(0) instanceof StenoLogSink
-                || metricsFactory.getSinks().get(0) instanceof TsdLogSink);
+        Assert.assertSame(sink, metricsFactory.getSinks().get(0));
 
         final Metrics metrics = metricsFactory.create();
         Assert.assertNotNull(metrics);
         Assert.assertTrue(metrics instanceof TsdMetrics);
         Mockito.verify(hostResolver).getLocalHostName();
+
+        final ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+        metrics.close();
+        Mockito.verify(sink).record(eventArgumentCaptor.capture());
+        final Event event = eventArgumentCaptor.getValue();
+        Assert.assertEquals("foo.example.com", event.getAnnotations().get("_host"));
+    }
+
+    @Test
+    public void testBuilderHostNameOverride() throws UnknownHostException {
+        final HostResolver hostResolver = Mockito.mock(HostResolver.class);
+        Mockito.doReturn("foo.example.com").when(hostResolver).getLocalHostName();
+        final Sink sink = Mockito.mock(Sink.class);
+
+        final TsdMetricsFactory metricsFactory = (TsdMetricsFactory) new TsdMetricsFactory.Builder(hostResolver)
+                .setClusterName("MyCluster")
+                .setServiceName("MyService")
+                .setHostName("bar.example.com")
+                .setSinks(Collections.singletonList(sink))
+                .build();
+
+        Assert.assertNotSame(hostResolver, metricsFactory.getHostResolver());
+        Assert.assertEquals("MyService", metricsFactory.getServiceName());
+        Assert.assertEquals("MyCluster", metricsFactory.getClusterName());
+        Assert.assertEquals(1, metricsFactory.getSinks().size());
+        Assert.assertSame(sink, metricsFactory.getSinks().get(0));
+
+        final Metrics metrics = metricsFactory.create();
+        Assert.assertNotNull(metrics);
+        Assert.assertTrue(metrics instanceof TsdMetrics);
+        Mockito.verify(hostResolver, Mockito.never()).getLocalHostName();
+
+        final ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+        metrics.close();
+        Mockito.verify(sink).record(eventArgumentCaptor.capture());
+        final Event event = eventArgumentCaptor.getValue();
+        Assert.assertEquals("bar.example.com", event.getAnnotations().get("_host"));
     }
 
     @Test
@@ -271,6 +310,4 @@ public class TsdMetricsFactoryTest {
         Assert.assertNotNull(asString);
         Assert.assertFalse(asString.isEmpty());
     }
-
-    private static final HostResolver DEFAULT_HOST_RESOLVER = new DefaultHostResolver();
 }


### PR DESCRIPTION
Delayed host resolution to creation of metrics instance. Switched from CachingHostResolver to BackgroundCachingHostResolver.

This does raise the question whether we should push the host name resolve right until close is invoked on the Metrics instance (as opposed to create). It is possible some use cases may have very long units of work -- even if that is not recommended.