### PR TITLE
Make UUID generation configurable via UuidFactory in the Metrics Factory.

### DIFF
--- a/src/main/java/com/arpnetworking/metrics/UuidFactory.java
+++ b/src/main/java/com/arpnetworking/metrics/UuidFactory.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2016 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics;
+
+import java.util.UUID;
+
+/**
+ * Interface for classes that provide UUIDs.
+ *
+ * @author Matthew Hayter (mhayter at groupon dot com)
+ */
+public interface UuidFactory {
+    /**
+     * Create a UUID; repeated invocations should provide unique UUIDs.
+     *
+     * @return A UUID.
+     */
+    UUID create();
+}

--- a/src/main/java/com/arpnetworking/metrics/impl/NativeRandomUuidFactory.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/NativeRandomUuidFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Groupon.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.UuidFactory;
+
+import java.util.UUID;
+
+/**
+ * Uses the java.util.UUID.randomUUID() to create UUIDs.
+ *
+ * @author Matthew Hayter (mhayter at groupon dot com)
+ */
+public class NativeRandomUuidFactory implements UuidFactory {
+    /**
+     * Uses the java.util.UUID.randomUUID() to create UUIDs.
+     *
+     * @return A UUID.
+     */
+    @Override
+    public UUID create() {
+        return UUID.randomUUID();
+    }
+}

--- a/src/main/java/com/arpnetworking/metrics/impl/TsdMetrics.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/TsdMetrics.java
@@ -437,15 +437,16 @@ public class TsdMetrics implements Metrics {
 
     // NOTE: Use an instance of TsdMetricsFactory to construct TsdMetrics instances.
     /* package private */ TsdMetrics(
-            final String serviceName,
+            final UUID uuid, final String serviceName,
             final String clusterName,
             final String hostName,
             final List<Sink> sinks) {
-        this(serviceName, clusterName, hostName, sinks, Clock.systemUTC(), LOGGER);
+        this(uuid, serviceName, clusterName, hostName, sinks, Clock.systemUTC(), LOGGER);
     }
 
     // NOTE: Package private for testing.
     /* package private */ TsdMetrics(
+            final UUID uuid,
             final String serviceName,
             final String clusterName,
             final String hostName,
@@ -456,7 +457,7 @@ public class TsdMetrics implements Metrics {
         _logger = logger;
         _clock = clock;
         _initialTimestamp = _clock.instant();
-        _annotations.put(ID_KEY, UUID.randomUUID().toString());
+        _annotations.put(ID_KEY, uuid.toString());
         _annotations.put(HOST_KEY, hostName);
         _annotations.put(SERVICE_KEY, serviceName);
         _annotations.put(CLUSTER_KEY, clusterName);

--- a/src/main/java/com/arpnetworking/metrics/impl/TsdMetricsFactory.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/TsdMetricsFactory.java
@@ -20,6 +20,7 @@ import com.arpnetworking.commons.hostresolver.HostResolver;
 import com.arpnetworking.metrics.Metrics;
 import com.arpnetworking.metrics.MetricsFactory;
 import com.arpnetworking.metrics.Sink;
+import com.arpnetworking.metrics.UuidFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +30,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Default implementation of <code>MetricsFactory</code> for creating
@@ -132,8 +134,10 @@ public class TsdMetricsFactory implements MetricsFactory {
      */
     @Override
     public Metrics create() {
+        final UUID uuid = _uuidFactory.create();
         try {
             return new TsdMetrics(
+                    uuid,
                     _serviceName,
                     _clusterName,
                     _hostResolver.getLocalHostName(),
@@ -146,6 +150,7 @@ public class TsdMetricsFactory implements MetricsFactory {
                             failures),
                     e);
             return new TsdMetrics(
+                    uuid,
                     _serviceName,
                     _clusterName,
                     DEFAULT_HOST_NAME,
@@ -198,6 +203,7 @@ public class TsdMetricsFactory implements MetricsFactory {
      */
     /* package private */ TsdMetricsFactory(final Builder builder, final Logger logger) {
         _sinks = Collections.unmodifiableList(new ArrayList<>(builder._sinks));
+        _uuidFactory = builder._uuidFactory;
         _serviceName = builder._serviceName;
         _clusterName = builder._clusterName;
         _hostResolver = builder._hostResolver;
@@ -205,6 +211,7 @@ public class TsdMetricsFactory implements MetricsFactory {
     }
 
     private final List<Sink> _sinks;
+    private final UuidFactory _uuidFactory;
     private final String _serviceName;
     private final String _clusterName;
     private final HostResolver _hostResolver;
@@ -308,6 +315,18 @@ public class TsdMetricsFactory implements MetricsFactory {
         }
 
         /**
+         * Set the UuidFactory to be used to create UUIDs assigned to instances of <code>Metrics</code> created by this
+         * <code>MetricsFactory</code>. Cannot be null. Optional. Defaults to using the Java native java.util.UUID.randomUUID().
+         *
+         * @param uuidFactory The UuidFactory instance.
+         * @return This <code>Builder</code> instance.
+         */
+        public Builder setUuidFactory(final UuidFactory uuidFactory) {
+            _uuidFactory = uuidFactory;
+            return this;
+        }
+
+        /**
          * Set the service name to publish as. Cannot be null.
          *
          * @param value The service name to publish as.
@@ -348,6 +367,7 @@ public class TsdMetricsFactory implements MetricsFactory {
         private final Logger _logger;
 
         private List<Sink> _sinks = Collections.singletonList(new StenoLogSink.Builder().build());
+        private UuidFactory _uuidFactory = new NativeRandomUuidFactory();
         private String _serviceName;
         private String _clusterName;
         private HostResolver _hostResolver;

--- a/src/test/java/com/arpnetworking/metrics/impl/TsdMetricsTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/TsdMetricsTest.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -931,6 +932,7 @@ public class TsdMetricsTest {
 
     private TsdMetrics createTsdMetrics(final Clock clock, final org.slf4j.Logger logger, final Sink... sinks) {
         return new TsdMetrics(
+                UUID.randomUUID(),
                 "MyService",
                 "MyCluster",
                 "MyHost",


### PR DESCRIPTION
@ddimensia is having trouble with the way `UUID.randomUuid()` uses synchronized methods and requested a configurable uuid generator.

N.B.: we discussed also adding a `create(UUID uuid)` to the `MetricsFactory` interface in order to control the uuid of individual `Metrics` instances (e.g. to set the same UUID as the related request), but I've not implemented that here without first running it by @BrandonArp / @vjkoskela as it seems a considerably more difficult a design decision.