### PR TITLE
No Operation Metrics

### DIFF
--- a/src/main/java/com/arpnetworking/metrics/impl/NoOpCounter.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/NoOpCounter.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Counter;
+import com.arpnetworking.metrics.Quantity;
+import com.arpnetworking.metrics.Unit;
+
+import javax.annotation.Nullable;
+
+/**
+ * No operation implementation of <code>Counter</code>.  This class is thread safe.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+/* package private */ final class NoOpCounter implements Counter, Quantity {
+    /**
+     * Package private constructor. All <code>NoOpCounter</code> instances should
+     * be created through the <code>NoOpMetrics</code> instance.
+     */
+    /* package private */ NoOpCounter() {
+        // Do nothing
+    }
+
+    @Override
+    public void increment() {
+        // Do nothing
+    }
+
+    @Override
+    public void decrement() {
+        // Do nothing
+    }
+
+    @Override
+    public void increment(final long value) {
+        // Do nothing
+    }
+
+    @Override
+    public void decrement(final long value) {
+        // Do nothing
+    }
+
+    @Override
+    public String toString() {
+        return "NoOpCounter";
+    }
+
+    @Override
+    public Number getValue() {
+        return 0;
+    }
+
+    @Override
+    @Nullable
+    public Unit getUnit() {
+        return null;
+    }
+}

--- a/src/main/java/com/arpnetworking/metrics/impl/NoOpMetrics.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/NoOpMetrics.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Counter;
+import com.arpnetworking.metrics.Metrics;
+import com.arpnetworking.metrics.Timer;
+import com.arpnetworking.metrics.Unit;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+
+/**
+ * Implementation of <code>Metrics</code> that provides safe interactions
+ * but does not actually publish any metrics. This is useful for merging
+ * codepaths where in one clients provide a <code>Metrics</code> instance
+ * and in another where they do not without having to resort to the use
+ * of <code>null</code> or <code>Optional</code>.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class NoOpMetrics implements Metrics {
+
+    @Override
+    public Counter createCounter(final String name) {
+        return new NoOpCounter();
+    }
+
+    @Override
+    public void incrementCounter(final String name) {
+        // Do nothing
+    }
+
+    @Override
+    public void incrementCounter(final String name, final long value) {
+        // Do nothing
+    }
+
+    @Override
+    public void decrementCounter(final String name) {
+        // Do nothing
+    }
+
+    @Override
+    public void decrementCounter(final String name, final long value) {
+        // Do nothing
+    }
+
+    @Override
+    public void resetCounter(final String name) {
+        // Do nothing
+    }
+
+    @Override
+    public Timer createTimer(final String name) {
+        return new NoOpTimer();
+    }
+
+    @Override
+    public void startTimer(final String name) {
+        // Do nothing
+    }
+
+    @Override
+    public void stopTimer(final String name) {
+        // Do nothing
+    }
+
+    /**
+     * @deprecated The use of TimeUnit directly in signatures is deprecated Use
+     * {@link Metrics#setTimer(String, long, Unit)} instead.
+     */
+    @Override
+    @Deprecated
+    public void setTimer(final String name, final long duration, @Nullable final TimeUnit unit) {
+        // Do nothing
+    }
+
+    @Override
+    public void setTimer(final String name, final long duration, @Nullable final Unit unit) {
+        // Do nothing
+    }
+
+    @Override
+    public void setGauge(final String name, final double value) {
+        // Do nothing
+    }
+
+    @Override
+    public void setGauge(final String name, final double value, @Nullable final Unit unit) {
+        // Do nothing
+    }
+
+    @Override
+    public void setGauge(final String name, final long value) {
+        // Do nothing
+    }
+
+    @Override
+    public void setGauge(final String name, final long value, @Nullable final Unit unit) {
+        // Do nothing
+    }
+
+    @Override
+    public void addAnnotation(final String key, final String value) {
+        // Do nothing
+    }
+
+    @Override
+    public void addAnnotations(final Map<String, String> map) {
+        // Do nothing
+    }
+
+    @Override
+    public boolean isOpen() {
+        return _isOpen.get();
+    }
+
+    @Override
+    public void close() {
+        if (_isOpen.getAndSet(false)) {
+            _finalTimestamp = _clock.instant();
+        }
+    }
+
+    @Override
+    @Nullable
+    public Instant getOpenTime() {
+        return _initialTimestamp;
+    }
+
+    @Override
+    @Nullable
+    public Instant getCloseTime() {
+        return _finalTimestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "NoOpMetrics";
+    }
+
+    /**
+     * Public constructor.
+     */
+    public NoOpMetrics() {
+        this(Clock.systemUTC());
+    }
+
+    /* package private */ NoOpMetrics(final Clock clock) {
+        _clock = clock;
+        _initialTimestamp = _clock.instant();
+    }
+
+    private final AtomicBoolean _isOpen = new AtomicBoolean(true);
+    private final Clock _clock;
+    private final Instant _initialTimestamp;
+    private Instant _finalTimestamp = null;
+}

--- a/src/main/java/com/arpnetworking/metrics/impl/NoOpMetricsFactory.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/NoOpMetricsFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Metrics;
+import com.arpnetworking.metrics.MetricsFactory;
+
+/**
+ * No operation implementation of <code>MetricsFactory</code>. This class is
+ * thread safe.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class NoOpMetricsFactory implements MetricsFactory {
+
+    @Override
+    public Metrics create() {
+        return new NoOpMetrics();
+    }
+
+    @Override
+    public String toString() {
+        return "NoOpMetricsFactory";
+    }
+}

--- a/src/main/java/com/arpnetworking/metrics/impl/NoOpTimer.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/NoOpTimer.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Quantity;
+import com.arpnetworking.metrics.Timer;
+import com.arpnetworking.metrics.Unit;
+import com.arpnetworking.metrics.Units;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+
+/**
+ * No operation implementation of <code>Timer</code>. This class is thread safe.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+/* package private */ final class NoOpTimer implements Timer, Quantity {
+    /**
+     * Package private constructor. All <code>NoOpTimer</code> instances should
+     * be created through the <code>NoOpMetrics</code> instance.
+     */
+    /* package private */ NoOpTimer() {
+        // Do nothing
+    }
+
+    @Override
+    public void stop() {
+        _isOpen.set(false);
+    }
+
+    @Override
+    public void close() {
+        _isOpen.set(false);
+    }
+
+    @Override
+    public void abort() {
+        _isAborted.set(true);
+    }
+
+    @Override
+    public Number getValue() {
+        return 0;
+    }
+
+    @Override
+    @Nullable
+    public Unit getUnit() {
+        return Units.NANOSECOND;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return _isOpen.get();
+    }
+
+    @Override
+    public boolean isAborted() {
+        return _isAborted.get();
+    }
+
+    @Override
+    public String toString() {
+        return "NoOpTimer";
+    }
+
+    private final AtomicBoolean _isOpen = new AtomicBoolean(true);
+    private final AtomicBoolean _isAborted = new AtomicBoolean(false);
+}

--- a/src/main/java/com/arpnetworking/metrics/impl/TsdCounter.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/TsdCounter.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of <code>Counter</code>.  This class is thread safe.
@@ -31,7 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 /* package private */ final class TsdCounter implements Counter, Quantity {
     /**
-     * Package private constructor. All <code>TsdCounter</code> instances should
+     * Package private static factory. All <code>TsdCounter</code> instances should
      * be created through the <code>TsdMetrics</code> instance.
      *
      * @param name The name of the counter.
@@ -81,6 +82,7 @@ import java.util.concurrent.atomic.AtomicLong;
     }
 
     @Override
+    @Nullable
     public Unit getUnit() {
         return null;
     }

--- a/src/main/java/com/arpnetworking/metrics/impl/TsdTimer.java
+++ b/src/main/java/com/arpnetworking/metrics/impl/TsdTimer.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of <code>Timer</code>. This class is thread safe.
@@ -32,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 /* package private */ final class TsdTimer implements Timer, Quantity {
     /**
-     * Package private constructor. All <code>TsdTimer</code> instances should
+     * Package private static factory. All <code>TsdTimer</code> instances should
      * be created through the <code>TsdMetrics</code> instance.
      *
      * @param name The name of the timer.
@@ -41,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
      * cyclical dependency between <code>TsdMetrics</code> and
      * <code>TsdTimer</code> which could cause garbage collection delays.
      */
-    /* package private */static TsdTimer newInstance(final String name, final AtomicBoolean isOpen) {
+    /* package private */ static TsdTimer newInstance(final String name, final AtomicBoolean isOpen) {
         return new TsdTimer(name, isOpen, DEFAULT_LOGGER);
     }
 
@@ -94,6 +95,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
     }
 
     @Override
+    @Nullable
     public Unit getUnit() {
         if (_stopWatch.isRunning()) {
             _logger.warn(String.format("Timer access before it is closed/stopped; timer=%s", this));

--- a/src/test/java/com/arpnetworking/metrics/impl/NoOpCounterTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/NoOpCounterTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for <code>NoOpCounter</code>.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class NoOpCounterTest {
+
+    @Test
+    public void testIncrement() {
+        final NoOpCounter counter = new NoOpCounter();
+        Assert.assertEquals(0L, counter.getValue().longValue());
+        Assert.assertNull(counter.getUnit());
+        counter.increment();
+        Assert.assertEquals(0L, counter.getValue().longValue());
+        Assert.assertNull(counter.getUnit());
+    }
+
+    @Test
+    public void testDecrement() {
+        final NoOpCounter counter = new NoOpCounter();
+        Assert.assertEquals(0L, counter.getValue().longValue());
+        Assert.assertNull(counter.getUnit());
+        counter.decrement();
+        Assert.assertEquals(0L, counter.getValue().longValue());
+        Assert.assertNull(counter.getUnit());
+    }
+
+    @Test
+    public void testIncrementByValue() {
+        final NoOpCounter counter = new NoOpCounter();
+        Assert.assertEquals(0L, counter.getValue().longValue());
+        Assert.assertNull(counter.getUnit());
+        counter.increment(2);
+        Assert.assertEquals(0L, counter.getValue().longValue());
+        Assert.assertNull(counter.getUnit());
+    }
+
+    @Test
+    public void testDecrementByValue() {
+        final NoOpCounter counter = new NoOpCounter();
+        Assert.assertEquals(0L, counter.getValue().longValue());
+        Assert.assertNull(counter.getUnit());
+        counter.decrement(2);
+        Assert.assertEquals(0L, counter.getValue().longValue());
+        Assert.assertNull(counter.getUnit());
+    }
+
+    @Test
+    public void testToString() {
+        final String asString = new NoOpCounter().toString();
+        Assert.assertNotNull(asString);
+        Assert.assertFalse(asString.isEmpty());
+        Assert.assertThat(asString, Matchers.containsString("NoOpCounter"));
+    }
+}

--- a/src/test/java/com/arpnetworking/metrics/impl/NoOpMetricsFactoryTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/NoOpMetricsFactoryTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Metrics;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for <code>NoOpMetricsFactory</code>.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class NoOpMetricsFactoryTest {
+
+    @Test
+    public void testCreate() {
+        final Metrics metrics = new NoOpMetricsFactory().create();
+        Assert.assertNotNull(metrics);
+        Assert.assertTrue(metrics instanceof NoOpMetrics);
+    }
+
+    @Test
+    public void testToString() {
+        final String asString = new NoOpMetricsFactory().toString();
+        Assert.assertNotNull(asString);
+        Assert.assertFalse(asString.isEmpty());
+        Assert.assertThat(asString, Matchers.containsString("NoOpMetricsFactory"));
+    }
+}

--- a/src/test/java/com/arpnetworking/metrics/impl/NoOpMetricsTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/NoOpMetricsTest.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Metrics;
+import com.arpnetworking.metrics.Units;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests for <code>NoOpMetrics</code>.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class NoOpMetricsTest {
+
+    @Test
+    public void testCreateCounter() {
+        final Metrics metrics = new NoOpMetrics();
+        Assert.assertNotNull(metrics.createCounter("aCounter"));
+        Assert.assertTrue(metrics.createCounter("aCounter") instanceof NoOpCounter);
+        Assert.assertNotSame(metrics.createCounter("aCounter"), metrics.createCounter("aCounter"));
+    }
+
+    @Test
+    public void testIncrementCounter() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.incrementCounter("aCounter");
+        // Does not throw.
+    }
+
+    @Test
+    public void testIncrementCounterByValue() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.incrementCounter("aCounter", 2);
+        // Does not throw.
+    }
+
+    @Test
+    public void testDecrementCounter() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.decrementCounter("aCounter");
+        // Does not throw.
+    }
+
+    @Test
+    public void testDecrementCounterByValue() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.decrementCounter("aCounter", 2);
+        // Does not throw.
+    }
+
+    @Test
+    public void testResetCounter() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.resetCounter("aCounter");
+        // Does not throw.
+    }
+
+    @Test
+    public void testCreateTimer() {
+        final Metrics metrics = new NoOpMetrics();
+        Assert.assertNotNull(metrics.createTimer("aTimer"));
+        Assert.assertTrue(metrics.createTimer("aTimer") instanceof NoOpTimer);
+        Assert.assertNotSame(metrics.createTimer("aTimer"), metrics.createTimer("aTimer"));
+    }
+
+    @Test
+    public void testStartTimer() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.startTimer("aTimer");
+        // Does not throw.
+    }
+
+    @Test
+    public void testStopTimer() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.stopTimer("aTimer");
+        // Does not throw.
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testSetTimerTimeUnit() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.setTimer("aTimer", 1, TimeUnit.SECONDS);
+        // Does not throw.
+    }
+
+    @Test
+    public void testSetTimerUnit() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.setTimer("aTimer", 1, Units.SECOND);
+        // Does not throw.
+    }
+
+    @Test
+    public void testSetGaugeDouble() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.setGauge("aGauge", 1.23d);
+        // Does not throw.
+    }
+
+    @Test
+    public void testSetGaugeDoubleUnit() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.setGauge("aGauge", 1.23d, Units.BITS_PER_SECOND);
+        // Does not throw.
+    }
+
+    @Test
+    public void testSetGaugeLong() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.setGauge("aGauge", 123L);
+        // Does not throw.
+    }
+
+    @Test
+    public void testSetGaugeLongUnit() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.setGauge("aGauge", 123L, Units.BITS_PER_SECOND);
+        // Does not throw.
+    }
+
+    @Test
+    public void testAddAnnotation() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.addAnnotation("foo", "bar");
+        // Does not throw.
+    }
+
+    @Test
+    public void testAddAnnotations() {
+        final Metrics metrics = new NoOpMetrics();
+        metrics.addAnnotations(Collections.singletonMap("foo", "bar"));
+        // Does not throw.
+    }
+
+    @Test
+    public void testClose() {
+        final Metrics metrics = new NoOpMetrics();
+        Assert.assertTrue(metrics.isOpen());
+        metrics.close();
+        Assert.assertFalse(metrics.isOpen());
+    }
+
+    @Test
+    public void testDoubleClose() throws InterruptedException {
+        final Instant now = Clock.systemUTC().instant();
+        final Metrics metrics = new NoOpMetrics();
+        Assert.assertTrue(metrics.isOpen());
+        metrics.close();
+        Assert.assertFalse(metrics.isOpen());
+        Assert.assertTrue(metrics.getCloseTime().compareTo(now) >= 0);
+        Thread.sleep(10);
+        final Instant later = Clock.systemUTC().instant();
+        metrics.close();
+        Assert.assertTrue(metrics.getCloseTime().compareTo(now) >= 0);
+        Assert.assertTrue(metrics.getCloseTime().compareTo(later) < 0);
+    }
+
+    @Test
+    public void testTimestamps() {
+        final Instant now = Clock.systemUTC().instant();
+        final Metrics metrics = new NoOpMetrics();
+        Assert.assertNotNull(metrics.getOpenTime());
+        Assert.assertNull(metrics.getCloseTime());
+        Assert.assertTrue(metrics.getOpenTime().compareTo(now) >= 0);
+        metrics.close();
+        Assert.assertFalse(metrics.isOpen());
+        Assert.assertNotNull(metrics.getCloseTime());
+        Assert.assertTrue(metrics.getCloseTime().compareTo(metrics.getOpenTime()) >= 0);
+    }
+
+    @Test
+    public void testToString() {
+        final String asString = new NoOpMetrics().toString();
+        Assert.assertNotNull(asString);
+        Assert.assertFalse(asString.isEmpty());
+        Assert.assertThat(asString, Matchers.containsString("NoOpMetrics"));
+    }
+}

--- a/src/test/java/com/arpnetworking/metrics/impl/NoOpTimerTest.java
+++ b/src/test/java/com/arpnetworking/metrics/impl/NoOpTimerTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2017 Inscope Metrics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.metrics.impl;
+
+import com.arpnetworking.metrics.Units;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for <code>NoOpTimer</code>.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public class NoOpTimerTest {
+
+    @Test
+    public void testGetValue() throws InterruptedException {
+        final NoOpTimer timer = new NoOpTimer();
+        Assert.assertEquals(0, timer.getValue());
+        timer.close();
+        Assert.assertEquals(0, timer.getValue());
+    }
+
+    @Test
+    public void testGetUnit() throws InterruptedException {
+        final NoOpTimer timer = new NoOpTimer();
+        Assert.assertEquals(Units.NANOSECOND, timer.getUnit());
+        timer.close();
+        Assert.assertEquals(Units.NANOSECOND, timer.getUnit());
+    }
+
+    @Test
+    public void testClose() throws InterruptedException {
+        final NoOpTimer timer;
+        try (NoOpTimer resourceTimer = new NoOpTimer()) {
+            timer = resourceTimer;
+            Assert.assertTrue(resourceTimer.isRunning());
+        }
+        Assert.assertFalse(timer.isRunning());
+    }
+
+    @Test
+    public void testStop() throws InterruptedException {
+        final NoOpTimer timer = new NoOpTimer();
+        Assert.assertTrue(timer.isRunning());
+        timer.stop();
+        Assert.assertFalse(timer.isRunning());
+    }
+
+    @Test
+    public void testAbort() throws InterruptedException {
+        final NoOpTimer timer = new NoOpTimer();
+        Assert.assertFalse(timer.isAborted());
+        timer.abort();
+        Assert.assertTrue(timer.isAborted());
+    }
+
+    @Test
+    public void testToString() {
+        final String asString = new NoOpTimer().toString();
+        Assert.assertNotNull(asString);
+        Assert.assertFalse(asString.isEmpty());
+        Assert.assertThat(asString, Matchers.containsString("NoOpTimer"));
+    }
+}


### PR DESCRIPTION
Add no-op metrics implementation to allow code paths where metrics may or may not be available to be unified without resorting to the use of null or Optional.